### PR TITLE
v0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "streamlit-keyup" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5a38037af547163566eff9fec0ee17a7e3556e4bf99b68d44327c726b8ea85b3
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  # s390x is missing streamlit
+  skip: true  # [py<37 or s390x]
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - streamlit >=1.2
+    - jinja2
+
+test:
+  imports:
+    - st_keyup
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/blackary/streamlit-keyup
+  dev_url:  https://github.com/blackary/streamlit-keyup
+  doc_url: https://github.com/blackary/streamlit-keyup/blob/main/README.md
+  summary: Text input that renders on keyup
+  description: |
+    If you're collecting text input from your users in your streamlit app, st.text_input 
+    works well -- as long as you're happy with waiting to get the response when they're finished typing.
+
+    But, what if you want to get the input out, and do something with it every time they type a new key (AKA "on keyup")?
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - ELundby45


### PR DESCRIPTION
# streamlit-keyup v0.2.0

`streamlit-extras` -> `streamlit-keyup`

upstream: https://github.com/blackary/streamlit-keyup

## Notes
- This is a new feedstock
- `s390x` is skipped due to missing streamlit
 